### PR TITLE
Remove a dangling tag and address a few typos

### DIFF
--- a/FAQ/index.html
+++ b/FAQ/index.html
@@ -100,12 +100,12 @@
           <div class="accordion-item">
             <h2 class="accordion-header" id="headingTwo">
               <button class="accordion-button collapsed lead" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
-                <i class="fas fa-question-circle fa-sm me-2 opacity-70"></i> Is there a VFX Reference Platform certified Linux distribution that I can download and install?
+                <i class="fas fa-question-circle fa-sm me-2 opacity-70"></i> Is there a VFX Reference Platform-certified Linux distribution that I can download and install?
               </button>
             </h2>
             <div id="collapseTwo" class="accordion-collapse collapse" aria-labelledby="headingTwo">
               <div class="accordion-body">
-                There is no VFX Reference Platform certified Linux distro available today so it is currently up to VFX and animation studios to take the recommended Linux distribution and upgrade/install the relevant platform versions. 
+                There is no VFX Reference Platform-certified Linux distro available today, so it is currently up to VFX and animation studios to take the recommended Linux distribution and upgrade/install the relevant platform versions. 
               </div>
             </div>
           </div>
@@ -146,9 +146,9 @@
             </h2>
             <div id="collapseSeven" class="accordion-collapse collapse" aria-labelledby="headingSeven">
               <div class="accordion-body">
-                The VFX Reference Platform is a collaborative project. So far, we have the enthusiastic support of all of the major application providers for the visual effects and animation industry, including Autodesk, The Foundry and Side Effects Software. 
+                The VFX Reference Platform is a collaborative project. So far, we have the enthusiastic support of all of the major application providers for the visual effects and animation industry, including Autodesk, Foundry and Side Effects Software.
                 <br>
-                There are two ways to participate: First, any interested person or company may join the discussion at <a href="mailto:vfx-platform-discuss@googlegroups.com">vfx-platform-discuss@googlegroups.com</a>. Second, we have formed a Working Group who hold regular conference calls to ensure progress is made in complicated areas. The Working group is made up of interested parties invited by the VES Technology Committee and currently has several members, one representative from the VES and one each from several software vendors.
+                There are two ways to participate: First, any interested person or company may join the discussion at <a href="mailto:vfx-platform-discuss@googlegroups.com">vfx-platform-discuss@googlegroups.com</a>. Second, we have formed a Working Group who hold regular conference calls to ensure progress is made in complicated areas. The Working Group is made up of interested parties invited by the VES Technology Committee and currently has several members, one representative from the VES and one each from several software vendors.
               </div>
             </div>
           </div>
@@ -169,7 +169,7 @@
           <div class="accordion-item">
             <h2 class="accordion-header" id="headingNine">
               <button class="accordion-button collapsed lead" type="button" data-bs-toggle="collapse" data-bs-target="#collapseNine" aria-expanded="false" aria-controls="collapseNine">
-                <i class="fas fa-question-circle fa-sm me-2 opacity-70"></i> My application provider doesn’t currently support the VFX Reference Platform, what should I do?
+                <i class="fas fa-question-circle fa-sm me-2 opacity-70"></i> My application provider doesn't currently support the VFX Reference Platform, what should I do?
               </button>
             </h2>
             <div id="collapseNine" class="accordion-collapse collapse" aria-labelledby="headingNine">
@@ -189,9 +189,9 @@
             </h2>
             <div id="collapseTen" class="accordion-collapse collapse" aria-labelledby="headingTen">
               <div class="accordion-body">
-                Linux is prevalent in VFX, particularly in the larger studios where they build sophisticated automation pipelines that integrate multiple different software vendors’ products together. These Linux-based pipelines are where the problem of conflicting versions most often manifests itself. This issue is made more complicated by the lack of standards across different Linux distros, hence our initial focus on Linux rather an any other OS.
+                Linux is prevalent in VFX, particularly in the larger studios where they build sophisticated automation pipelines that integrate multiple different software vendors' products together. These Linux-based pipelines are where the problem of conflicting versions most often manifests itself. This issue is made more complicated by the lack of standards across different Linux distros, hence our initial focus on Linux rather an any other OS.
                 <br/>
-                In 2020 we introduced support for macOS and Windows to encourage people to adopt and integrate more VFX and animation software regardless of their choice of operating system.</a>. 
+                In 2020 we introduced support for macOS and Windows to encourage people to adopt and integrate more VFX and animation software regardless of their choice of operating system.
               </div>
             </div>
           </div>
@@ -204,7 +204,7 @@
             </h2>
             <div id="collapseTwelve" class="accordion-collapse collapse" aria-labelledby="headingTwelve">
               <div class="accordion-body">
-                We partner with the <a href="https://aswf.io">Academy Software Foundation</a> on many initiatives and the <a href="https://github.com/AcademySoftwareFoundation/aswf-docker">ASWF Docker project</a> is an excellent resource providing easy to use Docker images of all the VFX Reference Platform components. These are created through an automated build system and you can consider the build process, and choice of compiler flags, as the canonical reference for build recipies.
+                We partner with the <a href="https://www.aswf.io/">Academy Software Foundation</a> on many initiatives, and the <a href="https://github.com/AcademySoftwareFoundation/aswf-docker">ASWF Docker project</a> is an excellent resource providing easy-to-use Docker images of all the VFX Reference Platform components. These are created through an automated build system, and you can consider the build process, and choice of compiler flags, as the canonical reference for build recipies.
               </div>
             </div>
           </div>
@@ -212,7 +212,7 @@
           <div class="accordion-item">
             <h2 class="accordion-header" id="headingForteen">
               <button class="accordion-button collapsed lead" type="button" data-bs-toggle="collapse" data-bs-target="#collapseForteen" aria-expanded="false" aria-controls="collapseForteen">
-                <i class="fas fa-question-circle fa-sm me-2 opacity-70"></i> When does a new version of an open source library need to be released in order for it to be considered for use by next year's batch of 3rd party software packages?
+                <i class="fas fa-question-circle fa-sm me-2 opacity-70"></i> When does a new version of an open source library need to be released in order for it to be considered for use by next year's batch of 3rd-party software packages?
               </button>
             </h2>
             <div id="collapseForteen" class="accordion-collapse collapse" aria-labelledby="headingForteen">


### PR DESCRIPTION
I came across the orphaned closing `</a>` tag and when removing that, decided to address a few other syntax things along the way.  I hope they're not too picky (well, they are, but . . . there you go).