### PR TITLE
Split off Imath and declare 2026 final.

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 
 		<p>The Calendar Year 2026 (CY2026) Reference Platform is the target for all major software releases in 2026.</p>
 
-		<p><strong>7th May 2025</strong> - CY2026 Draft published, with a number of significant changes to gcc, glibc, and Qt. We are currently soliciting feedback on this Draft so please either send to <a href="mailto:feedback@vfxplatform.com">feedback@vfxplatform.com</a> or share on <a href="https://groups.google.com/g/vfx-platform-discuss">vfx-platform-discuss</a>.</p>
+		<p><strong>5 November 2025</strong> - CY2026 is now Final and will be effective from January 1st. All package versions called out by the platform are now released. In 2021, the Imath library was split off from the OpenEXR 3 release into its own separately released package. Since Imath types are part of the OpenEXR API/ABI (as well other libraries such as Alembic), the OpenEXR / Imath maintainers have requested that the VFX Platform call out a specific, compatible version of Imath to avoid ambiguity.</p>
 
 		<p><a href="platform_history.html#previous-status-updates"><small>Previous status updates...</small></a></p>
 
@@ -157,6 +157,13 @@
                     <td class="fw-light">1.26.x</td>
                     <td class="fw-light">1.24.x</td>
                     <td class="fw-light">1.23.x</td>
+				</tr>
+				<tr>
+					<td class="fw-semibold">Imath</td>
+                    <td class="fw-light">3.2.x</td>
+                    <td class="fw-light">3.1.x</td>
+                    <td class="fw-light">3.1.x</td>
+                    <td class="fw-light">3.1.x</td>
 				</tr>
 				<tr>
 					<td class="fw-semibold">OpenEXR</td>

--- a/platform_history.html
+++ b/platform_history.html
@@ -237,6 +237,21 @@
                         <td class="fw-light">&nbsp;</td>
                     </tr>
                     <tr>
+                        <td class="fw-semibold">Imath</td>
+                        <td class="fw-light">3.1.x</td>
+                        <td class="fw-light">3.1.x</td>
+                        <td class="fw-light">3.1.x</td>
+                        <td class="fw-light">3.1.x</td>
+                        <td class="fw-light">3.0.x</td>
+                        <td class="fw-light">&nbsp;</td>
+                        <td class="fw-light">&nbsp;</td>
+                        <td class="fw-light">&nbsp;</td>
+                        <td class="fw-light">&nbsp;</td>
+                        <td class="fw-light">&nbsp;</td>
+                        <td class="fw-light">&nbsp;</td>
+                        <td class="fw-light">&nbsp;</td>
+                    </tr>
+                    <tr>
                         <td class="fw-semibold">OpenEXR</td>
                         <td class="fw-light">3.3.x</td>
                         <td class="fw-light">3.2.x</td>
@@ -421,6 +436,8 @@
     </div>
 
     <h3 class="display-6" id="previous-status-updates">Previous Status Updates</h3>
+
+    <p><strong>7th May 2025</strong> - CY2026 Draft published, with a number of significant changes to gcc, glibc, and Qt. We are currently soliciting feedback on this Draft so please either send to <a href="mailto:feedback@vfxplatform.com">feedback@vfxplatform.com</a> or share on <a href="https://groups.google.com/g/vfx-platform-discuss">vfx-platform-discuss</a>.</p>
 
         <p><strong>3rd November 2024</strong> - CY2025 updated to confirm the planned new releases for ACES, OpenColorIO, OpenEXR, and OpenVDB. </p>
 


### PR DESCRIPTION
As per OpenEXR maintainers, call out separate Imath version explicitly since Imath types are part of the OpenEXR / Alembic / OSL API/ABI, and we want to avoid having versions of those libraries compiled against different versions of Imath.

Also with the release of OpenVDB 13 we can declare VFX Platform 2026 as final.

You can preview the changes here:

https://jfpanisset.github.io/vfxplatform/index.html

