### PR TITLE
CY2027: Switch VisualStudio recommendation from product version to bu…

### DIFF
--- a/_data/notes.yml
+++ b/_data/notes.yml
@@ -100,3 +100,13 @@ notes:
       There is [a known issue compiling TBB 2020 with MSVC 2017](https://github.com/oneapi-src/oneTBB/issues/274) that can be resolved with [this workaround](https://github.com/oneapi-src/oneTBB/pull/299).
 
       Please plan to [migrate to oneTBB](https://www.intel.com/content/www/us/en/docs/onetbb/developer-guide-api-reference/2021-9/migrating-from-threading-building-blocks-tbb.htm) and have compatible releases published by September 1st 2024 to enable DCC providers to complete a planned move in CY2025. The original plan was to move to the oneAPI in CY2024 but more time was needed to migrate critical dependencies without impacting performance or introducing multiple conflicting thread pools.
+
+  - id: footnote-msvc-buildtool-versions
+    title: "Note - MSVC build tool versons"
+    from_year: 2027
+    content: |
+      There are many different version numbers that Microsoft use in the VisualStudio ecosystem. Build tool versions can be found [here](https://learn.microsoft.com/en-us/cpp/overview/compiler-versions?view=msvc-180#version-macros).
+
+      14.44 is the latest VS2022 build tools, supported until January 2032. VS2026 build tools start from 14.50. VisualStudio products can generally install current and older build tool versions side-by-side.
+
+      We will lean on Microsoft's [binary compatibility guarantee](https://learn.microsoft.com/en-us/cpp/porting/binary-compat-2015-2017?view=msvc-180).

--- a/_data/platforms/CY2027.yml
+++ b/_data/platforms/CY2027.yml
@@ -17,7 +17,7 @@ macos:
 
 windows:
   visual_studio:
-    version: "Visual Studio 2022 v17.14 or later"
+    version: "Visual Studio build tools v14.44 or later"
   sdk:
     version: "10.0.22621 or later"
 

--- a/_data/platforms/CY2027.yml
+++ b/_data/platforms/CY2027.yml
@@ -18,6 +18,7 @@ macos:
 windows:
   visual_studio:
     version: "Visual Studio build tools v14.44 or later"
+    note: footnote-msvc-buildtool-versions
   sdk:
     version: "10.0.22621 or later"
 

--- a/_data/platforms/CY2027.yml
+++ b/_data/platforms/CY2027.yml
@@ -1,6 +1,6 @@
 year: 2027
 status: draft
-last_updated: "2026-04-08"
+last_updated: "2026-06-03"
 
 linux:
   gcc:


### PR DESCRIPTION
…ild tools version as a minimum

* There are many different version numbers that Microsoft use in the VisualStudio ecosystem. See https://learn.microsoft.com/en-us/cpp/overview/compiler-versions?view=msvc-180#version-macros for more details.
* 14.44 is the latest VS2022 build tools, supported until January 2032
* VS2026 build tools start from 14.50
* We will put emphasis on Microsoft's binary compatibility guarantee, see https://learn.microsoft.com/en-us/cpp/porting/binary-compat-2015-2017?view=msvc-180